### PR TITLE
Tests that check for compressed file size should check range

### DIFF
--- a/kbase.yml
+++ b/kbase.yml
@@ -9,7 +9,7 @@ service-language:
     python
 
 module-version:
-    0.3.8
+    0.3.9
 
 owners:
     [gaprice, msneddon, jkbaumohl]

--- a/test/ReadsUtils_server_test.py
+++ b/test/ReadsUtils_server_test.py
@@ -1207,7 +1207,11 @@ class ReadsUtilsTest(unittest.TestCase):
         file_md5 = hashlib.md5(open(path, 'rb').read()).hexdigest()
         libfile = lib['file']
         self.assertEqual(file_md5, md5)
-        self.assertEqual(lib['size'], size)
+        size_buffer = 0.15  # allow +-15% size to permit a chagne in compression algorithm
+        min_size = int(float(size) * size_buffer - float(size))
+        max_size = int(float(size) * size_buffer + float(size))
+        self.assertGreater(lib['size'], min_size)
+        self.assertLess(lib['size'], max_size)
         self.assertEqual(lib['type'], 'fq')
         self.assertEqual(lib['encoding'], 'ascii')
 


### PR DESCRIPTION
Different GZip compression algorithms create files with different sizes. The tests previously checked for an exact number of bytes, which break when the compression algorithm or library changes. That just happened so I switched the tests to check a small window instead of an exact size.