### PR TITLE
Don't flag short "long reads" as invalid.

### DIFF
--- a/lib/ReadsUtils/ReadsUtilsImpl.py
+++ b/lib/ReadsUtils/ReadsUtilsImpl.py
@@ -888,7 +888,8 @@ class ReadsUtils:
 
             if validated:
                 arguments = [self.FASTQ_EXE, '--file', file_path,
-                             '--maxErrors', '10']
+                             '--maxErrors', '10',
+                             '--minReadLen', '1']
                 if p.get('interleaved'):
                     arguments.append('--disableSeqIDCheck')
                 retcode = subprocess.call(arguments)


### PR DESCRIPTION
Added "--minReadLen 1" to FASTQ validator call, so that reads of between 1 and 9 bases will be considered valid (the default minimum is 10 bases, which causes shorter long reads from Oxford Nanopore sequencing to be flagged as invalid)